### PR TITLE
Fix stylesheet to allow for widescreen monitors

### DIFF
--- a/doc/supplemental-ui/css/site-extra.css
+++ b/doc/supplemental-ui/css/site-extra.css
@@ -1,4 +1,30 @@
-/* Overall code block styling - Modern dark theme */
+/* ========================================
+   TOC SIDEBAR - Push to right edge
+   ======================================== */
+aside.toc.sidebar {
+    margin-left: auto;
+    margin-right: 0;
+}
+
+/* ========================================
+   MAIN CONTENT - Expand to fill space
+   ======================================== */
+@media screen and (min-width: 1024px) {
+    article.doc {
+        max-width: none;
+        flex-grow: 1;
+    }
+
+    /* Alternative: if the parent uses grid */
+    .body {
+        grid-template-columns: auto 1fr auto;
+    }
+}
+
+/* ========================================
+   CODE BLOCK STYLING - Modern dark theme
+   ======================================== */
+
 .listingblock .content pre,
 .listingblock .content pre.highlight,
 pre.highlight code.language-c\+\+ {


### PR DESCRIPTION
Goes from:

<img width="1614" height="627" alt="image" src="https://github.com/user-attachments/assets/af56572e-a497-4e6d-a9c6-1e55121f9ea6" />


To:

<img width="4572" height="1620" alt="image" src="https://github.com/user-attachments/assets/155a65a0-d8d8-43ef-8bbe-91c104f2c343" />
