### PR TITLE
Add requirements for Multi library usage

### DIFF
--- a/doc/modules/ROOT/pages/intro.adoc
+++ b/doc/modules/ROOT/pages/intro.adoc
@@ -85,4 +85,31 @@ such as representing algebraic dense matrices in the 2D case, or tensors in the 
 The library does not throw exceptions and provides basic exception guarantees (such as no memory leaks) in their presence (e.g., thrown from allocations).
 Indexing and other logical errors result in undefined behavior, which this library attempts to reflect via assertions.
 
+== Requirements
+
+:idprefix: reqs_
+
 _Multi_ is a header-only library and C++17 or later is required.
+
+The code requires any modern https://godbolt.org/z/hxEYGYEWc[C\++ compiler] (or https://godbolt.org/z/zvYoMjeTh[CUDA compiler]) with standard C\++17 support;
+for reference, (at least) any of:
+LLVM's          https://godbolt.org/z/51E1hjfnn[clang (5.0+)] (libc\++ and libstdc\++),
+GNU's           https://godbolt.org/z/1nGEbKc5a[g\++ (7.1+)],
+Nvidia's        https://godbolt.org/z/v9W889njx[nvcc (11.5+)] 
+and 
+                https://godbolt.org/z/6z39PjT47[nvc\++ (22.7+)],
+Intel's icpx (2022.0.0+) and icc (2021.1.2+, deprecated),
+Baxter's        https://www.circle-lang.org[circle] (https://godbolt.org/z/KeG417fMz[build 202+]),
+https://zig.news/kristoff/compile-a-c-c-project-with-zig-368j[Zig] in https://godbolt.org/z/cKGebsWMG[c++ mode (v0.9.0+)],
+Edison Design's https://edg.com/c[EDG] https://godbolt.org/z/693fxPedx[(6.5+)]
+and
+Microsoft's     https://visualstudio.microsoft.com/vs/features/cplusplus[MSVC] (https://godbolt.org/z/Kqrva137M[+14.1]).
+
+(Multi code inside CUDA kernel can be compiled with `nvcc` and with https://godbolt.org/z/7dTKdPTxc[clang (in CUDA mode)].
+Inside HIP code, it can be compiled with AMD's clang rocm (5.0+).)
+
+Optional _adaptor_ sublibraries (included in `multi/adaptors/`) have specific dependencies: fftw, , lapack, thurst, or CUDA
+(all of them can be installed with
+`sudo apt install libfftw3-dev lib64-dev liblapack64-dev libthrust-dev nvidia-cuda-dev`
+or `sudo dnf install fftw-devel ...`.
+)


### PR DESCRIPTION
Added requirements section detailing library dependencies and compiler support.

Gitlab's [![gitlabci](https://gitlab.com/correaa/boost-multi/badges/master/pipeline.svg)](https://gitlab.com/correaa/boost-multi/-/pipelines?page=1&scope=all)

This PR was open from a [Gitlab Merge request](https://gitlab.com/correaa/boost-multi/-/merge_requests/new),
it will be probably be merged from Gitlab, and then in can be closed here.

