### PR TITLE
Add link to Boost.Core in installation guide

### DIFF
--- a/doc/modules/ROOT/pages/install.adoc
+++ b/doc/modules/ROOT/pages/install.adoc
@@ -34,7 +34,7 @@ cmake . -B ./build  # --install-prefix=$HOME/.local
 cmake --install ./build  # or sudo ...
 ----
 
-_Testing_ the library requires Boost.Core (headers), installed for example, via
+_Testing_ the library requires link:https://www.boost.org/doc/libs/latest/libs/core/doc/html/core/lightweight_test.html[Boost.Core] (headers), installed for example, via
 `sudo apt install cmake git g{plus}{plus} libboost-test-dev make`
 or `sudo dnf install boost-devel cmake gcc-c{plus}{plus} git`.
 A CMake build system is provided to compile and run basic tests.


### PR DESCRIPTION
Updated installation instructions to include a link to Boost.Core documentation.

Gitlab's [![gitlabci](https://gitlab.com/correaa/boost-multi/badges/master/pipeline.svg)](https://gitlab.com/correaa/boost-multi/-/pipelines?page=1&scope=all)

This PR was open from a [Gitlab Merge request](https://gitlab.com/correaa/boost-multi/-/merge_requests/new),
it will be probably be merged from Gitlab, and then in can be closed here.

